### PR TITLE
Add optout_type to hook payload

### DIFF
--- a/identities/models.py
+++ b/identities/models.py
@@ -184,6 +184,7 @@ def handle_optout(sender, instance, created, **kwargs):
         event_name='optout.requested',
         payload={
             'details': identity.details,
+            'optout_type': instance.optout_type,
         },
         user=instance.user,
         send_hook_meta=False

--- a/identities/tests.py
+++ b/identities/tests.py
@@ -621,7 +621,8 @@ class TestOptOutAPI(AuthenticatedAPITestCase):
                         "+27123": {}
                     }
                 }
-            }
+            },
+            "optout_type": "forget"
         }
         responses.add(
             responses.POST,
@@ -646,6 +647,7 @@ class TestOptOutAPI(AuthenticatedAPITestCase):
         identity = self.make_identity()
         payload = {
             'details': identity.details,
+            'optout_type': "forget",
         }
         responses.add(
             responses.POST,
@@ -679,6 +681,7 @@ class TestOptOutAPI(AuthenticatedAPITestCase):
         identity = self.make_identity()
         payload = {
             'details': identity.details,
+            'optout_type': "stop",
         }
         responses.add(
             responses.POST,
@@ -720,6 +723,7 @@ class TestOptOutAPI(AuthenticatedAPITestCase):
         identity = self.make_identity()
         payload = {
             'details': identity.details,
+            'optout_type': "stopall",
         }
         responses.add(
             responses.POST,


### PR DESCRIPTION
This should inform applications what type of optout has been created for the identity.

Previously the payload sent in the hook when an optout was created only contained the details for the Identity before they opted out. There was no way to determine what sort of optout they had sent.
