### PR TITLE
MSISDN change metric

### DIFF
--- a/identities/models.py
+++ b/identities/models.py
@@ -9,6 +9,8 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.core.exceptions import ValidationError
 from rest_hooks.signals import raw_hook_event
 
+ADDRESS_TYPES = ['msisdn', 'email']
+
 
 class IdentityManager(models.Manager):
 
@@ -74,22 +76,25 @@ class Identity(models.Model):
         return str(self.id)
 
     def save(self, *args, **kwargs):
-        if self.id and not self._state.adding:
+        if (self.id and not self._state.adding and
+                self.details.get('name') != "redacted"):
             old_id = Identity.objects.get(pk=self.id)
 
-            old_keys = [str(k) for k in
-                        old_id.details.get('addresses', {}).get('msisdn', {})
-                        .keys()]
-            new_keys = [str(k) for k in
-                        self.details.get('addresses', {}).get('msisdn', {})
-                        .keys()]
+            for address_type in ADDRESS_TYPES:
+                old_keys = [str(k) for k in
+                            old_id.details.get('addresses', {}).get(
+                            address_type, {}).keys()]
+                new_keys = [str(k) for k in
+                            self.details.get('addresses', {}).get(
+                            address_type, {}).keys()]
 
-            if (old_keys != new_keys):
-                from .tasks import fire_metric
-                fire_metric.apply_async(kwargs={
-                    "metric_name": 'registrations.change.msisdn.sum',
-                    "metric_value": 1.0
-                })
+                if (set(old_keys) != set(new_keys)):
+                    from .tasks import fire_metric
+                    fire_metric.apply_async(kwargs={
+                        "metric_name": 'identities.change.{}.sum'.format(
+                            address_type),
+                        "metric_value": 1.0
+                    })
 
         super(Identity, self).save(*args, **kwargs)
 

--- a/identities/models.py
+++ b/identities/models.py
@@ -9,7 +9,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.core.exceptions import ValidationError
 from rest_hooks.signals import raw_hook_event
 
-ADDRESS_TYPES = ['msisdn', 'email']
+from seed_identity_store.settings import ADDRESS_TYPES
 
 
 class IdentityManager(models.Manager):

--- a/seed_identity_store/settings.py
+++ b/seed_identity_store/settings.py
@@ -189,7 +189,6 @@ CELERY_ROUTES = {
 
 METRICS_REALTIME = [
     'identities.created.sum',
-    'registrations.change.msisdn.sum',
 ]
 METRICS_SCHEDULED = [
     'identities.created.last'

--- a/seed_identity_store/settings.py
+++ b/seed_identity_store/settings.py
@@ -187,9 +187,15 @@ CELERY_ROUTES = {
     }
 }
 
+ADDRESS_TYPES = ['msisdn', 'email']
+
 METRICS_REALTIME = [
     'identities.created.sum',
 ]
+
+METRICS_REALTIME.extend(
+    ['identities.change.%s.sum' % at for at in ADDRESS_TYPES])
+
 METRICS_SCHEDULED = [
     'identities.created.last'
 ]

--- a/seed_identity_store/settings.py
+++ b/seed_identity_store/settings.py
@@ -188,7 +188,8 @@ CELERY_ROUTES = {
 }
 
 METRICS_REALTIME = [
-    'identities.created.sum'
+    'identities.created.sum',
+    'registrations.change.msisdn.sum',
 ]
 METRICS_SCHEDULED = [
     'identities.created.last'

--- a/seed_identity_store/utils.py
+++ b/seed_identity_store/utils.py
@@ -1,13 +1,9 @@
 from django.conf import settings
-from identities.models import ADDRESS_TYPES
 
 
 def get_available_metrics():
     available_metrics = []
     available_metrics.extend(settings.METRICS_REALTIME)
     available_metrics.extend(settings.METRICS_SCHEDULED)
-
-    for a_type in ADDRESS_TYPES:
-        available_metrics.append('identities.change.{}.sum'.format(a_type))
 
     return available_metrics

--- a/seed_identity_store/utils.py
+++ b/seed_identity_store/utils.py
@@ -1,9 +1,13 @@
 from django.conf import settings
+from identities.models import ADDRESS_TYPES
 
 
 def get_available_metrics():
     available_metrics = []
     available_metrics.extend(settings.METRICS_REALTIME)
     available_metrics.extend(settings.METRICS_SCHEDULED)
+
+    for a_type in ADDRESS_TYPES:
+        available_metrics.append('identities.change.{}.sum'.format(a_type))
 
     return available_metrics


### PR DESCRIPTION
This PR adds the "identities.change.{address_type}.sum" metric. We only add the sum and not the total.last metric because there is no way to count how many changes have happened in the past.