### PR TITLE
Switch the vumi go metric client to the seed metric client

### DIFF
--- a/identities/tasks.py
+++ b/identities/tasks.py
@@ -3,7 +3,7 @@ import uuid
 import requests
 from celery.task import Task
 from django.conf import settings
-from go_http.metrics import MetricsApiClient
+from seed_services_client.metrics import MetricsApiClient
 from .models import Identity, DetailKey
 from seed_papertrail.decorators import papertrail
 
@@ -41,8 +41,8 @@ def deliver_hook_wrapper(target, payload, instance, hook):
 
 def get_metric_client(session=None):
     return MetricsApiClient(
-        auth_token=settings.METRICS_AUTH_TOKEN,
-        api_url=settings.METRICS_URL,
+        url=settings.METRICS_URL,
+        auth=settings.METRICS_AUTH,
         session=session)
 
 
@@ -60,7 +60,7 @@ class FireMetric(Task):
         }
         try:
             metric_client = get_metric_client(session=session)
-            metric_client.fire(metric)
+            metric_client.fire_metrics(**metric)
             return "Fired metric <%s> with value <%s>" % (
                 metric_name, metric_value)
         except (requests.exceptions.HTTPError,) as e:

--- a/seed_identity_store/settings.py
+++ b/seed_identity_store/settings.py
@@ -226,7 +226,10 @@ CELERYD_MAX_TASKS_PER_CHILD = 50
 djcelery.setup_loader()
 
 METRICS_URL = os.environ.get("METRICS_URL", None)
-METRICS_AUTH_TOKEN = os.environ.get("METRICS_AUTH_TOKEN", "REPLACEME")
+METRICS_AUTH = (
+    os.environ.get("METRICS_AUTH_USER", "REPLACEME"),
+    os.environ.get("METRICS_AUTH_PASSWORD", "REPLACEME"),
+)
 
 
 PAPERTRAIL = os.environ.get('PAPERTRAIL')

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'redis==2.10.5',
         'pytz==2015.7',
         'django-rest-hooks==1.3.1',
-        'go-http==0.3.0',
+        'seed-services-client>=0.21.0',
         'drfdocs==0.0.11',
         'seed-papertrail>=1.5.1',
     ],


### PR DESCRIPTION
Currently, we are using the vumi go metric client. While this works for the seed metric API, vumi go uses token authentication, and seed uses basic authentication, so in order to implement authentication with the seed metric API, we need to switch the vumi go metric client with the seed metric client