### PR TITLE
Remove msisdn on forget optout

### DIFF
--- a/identities/models.py
+++ b/identities/models.py
@@ -349,6 +349,7 @@ def handle_optout(sender, instance, created, **kwargs):
 
     if instance.optout_type == "forget":
         identity.remove_details(instance.user)
+        OptOut.objects.filter(id=instance.id).update(address="redacted")
     elif instance.optout_type == "stop":
         identity.optout_address(scope="single",
                                 address_type=instance.address_type,

--- a/identities/tests.py
+++ b/identities/tests.py
@@ -1592,6 +1592,25 @@ class TestOptOutAPI(AuthenticatedAPITestCase):
             }
         })
 
+    @responses.activate
+    def test_optout_forget_remove_address(self):
+        """
+        When a forget optout is created the msisdn should be removed.
+        """
+        # Setup
+        post_save.connect(receiver=handle_optout, sender=OptOut)
+        user = User.objects.get(username='testuser')
+        identity = self.make_identity()
+
+        optout = OptOut.objects.create(
+            identity=identity, created_by=user, request_source="test_source",
+            requestor_source_id=1, address_type="msisdn", address="+27123",
+            optout_type="forget")
+
+        optout.refresh_from_db()
+
+        self.assertEqual(optout.address, "redacted")
+
 
 class TestHealthcheckAPI(AuthenticatedAPITestCase):
 


### PR DESCRIPTION
Currently we keep the msisdn after the user requests that we remove all their data, this PR will delete the msisdn after we have processed the optout.