### PR TITLE
Add prometheus monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *,cover
+.pytest_cache
 
 # Translations
 *.mo

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -7,7 +7,7 @@ Overview
 
 The Seed Identity Store requires the following dependencies to run:
 
-* Python 2.7
+* Python 3.6
 * PostgreSQL >= 9.3
 * Redis >= 2.10 or RabbitMQ >= 3.4 as the Celery Broker
 
@@ -17,19 +17,15 @@ Python requirements
 The full list of Python packages required are detailed in the project's
 setup.py file, but the major ones are:
 
-* Django 1.9
-* Django REST Framework 3.3
-* Celery 3.1
+* Django 2.1
+* Django REST Framework 3.9
+* Celery 4.2
 
 .. note::
 
-    A celery worker needs to be running to process post-save tasks and
-    scheduled metric firing tasks.
+    A celery worker needs to be running to process post-save tasks
 
 Seed Requirements
 =================
 
-The Seed Identity Store only depends on one other seed service, the
-`Go Metrics API`_.
-
-.. _Go Metrics API: https://github.com/praekelt/go-metrics-api
+The Seed Identity Store doesn't depends on any other seed services

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -84,13 +84,3 @@ The following environmental variables can be used to override some default setti
 .. envvar:: BROKER_URL
 
     The Broker URL to use with Celery.
-
-.. envvar:: METRICS_URL
-
-    The URL to the `Go Metrics API`_ instance to push metrics to.
-
-.. _Go Metrics API: https://github.com/praekelt/go-metrics-api
-
-.. envvar:: METRICS_AUTH_TOKEN
-
-    The `auth token` to use to connect to the `Go Metrics API`_ above.

--- a/identities/tasks.py
+++ b/identities/tasks.py
@@ -5,7 +5,6 @@ import requests
 from celery.task import Task
 from django.conf import settings
 from seed_papertrail.decorators import papertrail
-from seed_services_client.metrics import MetricsApiClient
 
 from .models import DetailKey
 
@@ -40,58 +39,6 @@ def deliver_hook_wrapper(target, payload, instance, hook):
         target=target, payload=payload, instance_id=instance_id, hook_id=hook.id
     )
     DeliverHook.apply_async(kwargs=kwargs)
-
-
-def get_metric_client(session=None):
-    return MetricsApiClient(
-        url=settings.METRICS_URL, auth=settings.METRICS_AUTH, session=session
-    )
-
-
-class FireMetric(Task):
-
-    """ Fires a metric using the MetricsApiClient
-    """
-
-    name = "seed_identity_store.identities.tasks.fire_metric"
-
-    @papertrail.debug(name)
-    def run(self, metric_name, metric_value, session=None, **kwargs):
-        metric_value = float(metric_value)
-        metric = {metric_name: metric_value}
-        try:
-            metric_client = get_metric_client(session=session)
-            metric_client.fire_metrics(**metric)
-            return "Fired metric <%s> with value <%s>" % (metric_name, metric_value)
-        except (requests.exceptions.HTTPError,) as e:
-            return "Failed to fire metric <%s> with value <%s> because %s" % (
-                metric_name,
-                metric_value,
-                e,
-            )
-
-
-fire_metric = FireMetric()
-
-
-class ScheduledMetrics(Task):
-
-    """ Fires off tasks for all the metrics that should run
-        on a schedule
-    """
-
-    name = "seed_identity_store.subscriptions.tasks.scheduled_metrics"
-
-    @papertrail.debug(name)
-    def run(self, **kwargs):
-        globs = globals()  # execute globals() outside for loop for efficiency
-        for metric in settings.METRICS_SCHEDULED_TASKS:
-            globs[metric].apply_async()
-
-        return "%d Scheduled metrics launched" % len(settings.METRICS_SCHEDULED_TASKS)
-
-
-scheduled_metrics = ScheduledMetrics()
 
 
 class PopulateDetailKey(Task):

--- a/identities/views.py
+++ b/identities/views.py
@@ -14,8 +14,6 @@ from rest_framework.views import APIView
 from rest_hooks.models import Hook
 from rest_hooks.signals import raw_hook_event
 
-from seed_identity_store.utils import get_available_metrics
-
 from .models import DetailKey, Identity, OptIn, OptOut
 from .serializers import (
     AddressSerializer,
@@ -27,7 +25,6 @@ from .serializers import (
     OptOutSerializer,
     UserSerializer,
 )
-from .tasks import scheduled_metrics
 
 
 class CreatedAtCursorPagination(CursorPagination):
@@ -375,7 +372,7 @@ class HookViewSet(viewsets.ModelViewSet):
 
 
 class MetricsView(APIView):
-
+    # This is here for backwards compatibility with the Control Interface
     """ Metrics Interaction
         GET - returns list of all available metrics on the service
         POST - starts up the task that fires all the scheduled metrics
@@ -385,12 +382,11 @@ class MetricsView(APIView):
 
     def get(self, request, *args, **kwargs):
         status = 200
-        resp = {"metrics_available": get_available_metrics()}
+        resp = {"metrics_available": []}
         return Response(resp, status=status)
 
     def post(self, request, *args, **kwargs):
         status = 201
-        scheduled_metrics.apply_async()
         resp = {"scheduled_metrics_initiated": True}
         return Response(resp, status=status)
 

--- a/seed_identity_store/decorators.py
+++ b/seed_identity_store/decorators.py
@@ -1,0 +1,21 @@
+import functools
+
+from django.core.exceptions import PermissionDenied
+
+
+def internal_only(view_func):
+    """
+    A view decorator which blocks access for requests coming through the load balancer.
+    """
+
+    @functools.wraps(view_func)
+    def wrapper(request, *args, **kwargs):
+        forwards = request.META.get("HTTP_X_FORWARDED_FOR", "").split(",")
+        # The nginx in the docker container adds the loadbalancer IP to the list inside
+        # X-Forwarded-For, so if the list contains more than a single item, we know
+        # that it went through our loadbalancer
+        if len(forwards) > 1:
+            raise PermissionDenied()
+        return view_func(request, *args, **kwargs)
+
+    return wrapper

--- a/seed_identity_store/settings.py
+++ b/seed_identity_store/settings.py
@@ -174,33 +174,16 @@ CELERY_TASK_CREATE_MISSING_QUEUES = True
 CELERY_TASK_ROUTES = {
     "celery.backend_cleanup": {"queue": "mediumpriority"},
     "identities.tasks.DeliverHook": {"queue": "priority"},
-    "identities.tasks.fire_metric": {"queue": "metrics"},
-    "identities.tasks.scheduled_metrics": {"queue": "metrics"},
-    "identities.tasks.fire_active_last": {"queue": "metrics"},
     "identities.tasks.populate_detail_key": {"queue": "priority"},
 }
 
 ADDRESS_TYPES = ["msisdn", "email"]
-
-METRICS_REALTIME = ["identities.created.sum", "optout.sum"]
-
-METRICS_REALTIME.extend(["identities.change.%s.sum" % at for at in ADDRESS_TYPES])
-
-METRICS_SCHEDULED = []
-METRICS_SCHEDULED_TASKS = []
 
 CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
 CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TASK_IGNORE_RESULT = True
 CELERY_WORKER_MAX_TASKS_PER_CHILD = 50
-
-METRICS_URL = os.environ.get("METRICS_URL", None)
-METRICS_AUTH = (
-    os.environ.get("METRICS_AUTH_USER", "REPLACEME"),
-    os.environ.get("METRICS_AUTH_PASSWORD", "REPLACEME"),
-)
-
 
 PAPERTRAIL = os.environ.get("PAPERTRAIL")
 if PAPERTRAIL:

--- a/seed_identity_store/settings.py
+++ b/seed_identity_store/settings.py
@@ -45,17 +45,20 @@ INSTALLED_APPS = (
     "rest_framework.authtoken",
     "django_filters",
     "rest_hooks",
+    "django_prometheus",
     # us
     "identities",
 )
 
 MIDDLEWARE = (
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 )
 
 ROOT_URLCONF = "seed_identity_store.urls"
@@ -70,9 +73,12 @@ DATABASES = {
     "default": dj_database_url.config(
         default=os.environ.get(
             "IDENTITIES_DATABASE", "postgres://postgres:@localhost/seed_identity_store"
-        )
+        ),
+        engine="django_prometheus.db.backends.postgresql",
     )
 }
+
+PROMETHEUS_EXPORT_MIGRATIONS = False
 
 
 # Internationalization

--- a/seed_identity_store/test_decorators.py
+++ b/seed_identity_store/test_decorators.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+
+
+class InternalOnlyTests(TestCase):
+    def test_internal_access(self):
+        """
+        Internal access should be allowed
+        """
+        url = reverse("metrics")
+        response = self.client.get(url, HTTP_X_FORWARDED_FOR="1.2.3.4")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_external_access(self):
+        """
+        External access through the load balancer should be blocked
+        """
+        url = reverse("metrics")
+        response = self.client.get(url, HTTP_X_FORWARDED_FOR="1.2.3.4, 4.3.2.1")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/seed_identity_store/testsettings.py
+++ b/seed_identity_store/testsettings.py
@@ -12,8 +12,7 @@ CELERY_TASK_EAGER_PROPAGATES = True
 CELERY_TASK_ALWAYS_EAGER = True
 BROKER_BACKEND = "memory"
 
-METRICS_URL = "http://metrics-url"
-METRICS_AUTH_TOKEN = "REPLACEME"
-
 # REST Framework conf defaults
 REST_FRAMEWORK["PAGE_SIZE"] = 2  # noqa: F405
+
+PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]

--- a/seed_identity_store/urls.py
+++ b/seed_identity_store/urls.py
@@ -4,6 +4,7 @@ import rest_framework.authtoken.views as rf_views
 from django.conf.urls import url
 from django.contrib import admin
 from django.urls import include, path
+from django_prometheus import exports as django_prometheus
 from rest_framework.documentation import include_docs_urls
 
 from identities import views
@@ -19,4 +20,5 @@ urlpatterns = [
     url(r"^api/health/", views.HealthcheckView.as_view()),
     url(r"^", include("identities.urls")),
     path("docs/", include_docs_urls(title=admin.site.site_header)),
+    path("metrics", django_prometheus.ExportToDjangoView, name="metrics"),
 ]

--- a/seed_identity_store/urls.py
+++ b/seed_identity_store/urls.py
@@ -8,6 +8,7 @@ from django_prometheus import exports as django_prometheus
 from rest_framework.documentation import include_docs_urls
 
 from identities import views
+from seed_identity_store.decorators import internal_only
 
 admin.site.site_header = os.environ.get("IDENTITIES_TITLE", "Seed Identity Store Admin")
 
@@ -20,5 +21,7 @@ urlpatterns = [
     url(r"^api/health/", views.HealthcheckView.as_view()),
     url(r"^", include("identities.urls")),
     path("docs/", include_docs_urls(title=admin.site.site_header)),
-    path("metrics", django_prometheus.ExportToDjangoView, name="metrics"),
+    path(
+        "metrics", internal_only(django_prometheus.ExportToDjangoView), name="metrics"
+    ),
 ]

--- a/seed_identity_store/utils.py
+++ b/seed_identity_store/utils.py
@@ -1,9 +1,0 @@
-from django.conf import settings
-
-
-def get_available_metrics():
-    available_metrics = []
-    available_metrics.extend(settings.METRICS_REALTIME)
-    available_metrics.extend(settings.METRICS_SCHEDULED)
-
-    return available_metrics

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         "django-rest-hooks==1.5.0",
         "seed-services-client>=0.31.0",
         "seed-papertrail>=1.5.1",
+        "django-prometheus==1.0.15",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
This PR adds the basic django prometheus monitoring metrics to the application.

It also removes any old metrics code, and replaces any relevant ones with prometheus metrics instead