### PR TITLE
Upgrade djangorestframework and Django

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "Django==2.1.4",
-        "djangorestframework==3.9.0",
+        "djangorestframework==3.9.1",
         "coreapi==2.3.3",
         "dj-database-url==0.5.0",
         "psycopg2==2.7.6.1",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        "Django==2.1.4",
+        "Django==2.2.3",
         "djangorestframework==3.9.1",
         "coreapi==2.3.3",
         "dj-database-url==0.5.0",


### PR DESCRIPTION
Both the current versions of djangorestframework and Django have vulnerabilities.

For Django, I've gone up a minor step, so that we can be on the LTS release.